### PR TITLE
Content.attachBytes is missing fileName on message part

### DIFF
--- a/src/main/scala/com/github/jurajburian/mailer/Mailer.scala
+++ b/src/main/scala/com/github/jurajburian/mailer/Mailer.scala
@@ -105,6 +105,7 @@ case class Content(parts: MimeBodyPart*) {
 		val part = new MimeBodyPart()
 		contentId.foreach(part.setContentID)
 		part.setDataHandler(new DataHandler(new ByteArrayDataSource(bytes, mimeType)))
+		name.foreach(part.setFileName)
 		headers.foreach(header => part.setHeader(header.name, header.value))
 		append(part)
 	}


### PR DESCRIPTION
Content.attachBytes is not setting the provided filename. This make services such as gmail ignoring the attachment and inserting the content into the mail body.