### PR TITLE
Override updateMessageID to set a custom message id.

### DIFF
--- a/src/main/scala/com/github/jurajburian/mailer/Mailer.scala
+++ b/src/main/scala/com/github/jurajburian/mailer/Mailer.scala
@@ -1,8 +1,9 @@
 package com.github.jurajburian.mailer
 
 import java.io.File
+
 import javax.activation.{DataHandler, FileDataSource}
-import javax.mail.internet._
+import javax.mail.internet.{InternetAddress, MimeBodyPart, MimeMultipart, PreencodedMimeBodyPart}
 import javax.mail.util.ByteArrayDataSource
 import javax.mail.{MessagingException, Session, Transport}
 

--- a/src/main/scala/com/github/jurajburian/mailer/MimeMessage.scala
+++ b/src/main/scala/com/github/jurajburian/mailer/MimeMessage.scala
@@ -1,0 +1,15 @@
+package com.github.jurajburian.mailer
+
+import javax.mail.Session
+import javax.mail.internet.{MimeMessage => JavaMimeMessage}
+
+class MimeMessage(session: Session) extends JavaMimeMessage(session) {
+
+  override def updateMessageID(): Unit = {
+    Option(headers.getHeader("Message-ID", null)) match {
+      case Some(_) => ()
+      case None    => super.updateMessageID()
+    }
+  }
+
+}

--- a/src/test/scala/com/github/jurajburian/mailer/MailerSpec.scala
+++ b/src/test/scala/com/github/jurajburian/mailer/MailerSpec.scala
@@ -20,6 +20,7 @@ class MailerSpec extends FlatSpec with Matchers {
 	val SmtpHost = "localhost"
 	val SmtpPort = 25
 	val TestHeader = CustomHeader("TEST_NAME", "TEST_VALUE")
+	val TestHeaderMessageId = CustomHeader("Message-ID", "some-message-id")
 
 	"Session" should "parse set of properties and return correct value" in {
 		val session = (SmtpAddress(SmtpHost, SmtpPort) :: Debug(true) :: SmtpTimeout(1000) :: SessionFactory()).session()
@@ -37,7 +38,7 @@ class MailerSpec extends FlatSpec with Matchers {
 			subject = MessageSubject,
 			content = content,
 			to = Seq(new internet.InternetAddress(RecipientAddress)),
-			headers = Seq(TestHeader)
+			headers = Seq(TestHeader, TestHeaderMessageId)
 		))
 
 		// open the fake INBOX folder
@@ -57,6 +58,7 @@ class MailerSpec extends FlatSpec with Matchers {
 		firstMessage.getFrom()(0).toString should be(SenderAddress)
 		firstMessage.getAllRecipients()(0).toString should be(RecipientAddress)
 		firstMessage.getHeader(TestHeader.name)(0) should be(TestHeader.value)
+		firstMessage.getHeader(TestHeaderMessageId.name)(0) should be(TestHeaderMessageId.value)
 
 		// check whether the content parts in the MimeMultipart message are correct
 		firstContent should be(an[MimeMultipart])


### PR DESCRIPTION
If no message id header is provided the usual behavior is used to generate one.
This is according to the FAQ guidelines: https://javaee.github.io/javamail/FAQ#msgid